### PR TITLE
(Mine Faker) Allow .ssc files with missing song-level timing fields.

### DIFF
--- a/make_mines_fake.py
+++ b/make_mines_fake.py
@@ -141,7 +141,8 @@ def splittiming(ssc: simfile.ssc.SSCSimfile, chart: simfile.ssc.SSCChart) -> Non
         "SCROLLS",
         "FAKES",
     ):
-        chart[td] = ssc[td]
+        if td in ssc:
+            chart[td] = ssc[td]
 
 
 ################


### PR DESCRIPTION
Logic in the mine faker to copy a song's timing data into each chart previously assumed all timing fields were always present at the song level. This causes 500s for files with forced split timing if they're missing any song-level timing fields:

```
2023-06-22T00:35:33.557711+00:00 app[web.1]: [2023-06-22 00:35:33,557] ERROR in app: Exception on /fake-mines [POST]
2023-06-22T00:35:33.557740+00:00 app[web.1]: Traceback (most recent call last):
2023-06-22T00:35:33.557741+00:00 app[web.1]:   File "/app/.heroku/python/lib/python3.10/site-packages/flask/app.py", line 2528, in wsgi_app
2023-06-22T00:35:33.557741+00:00 app[web.1]:     response = self.full_dispatch_request()
2023-06-22T00:35:33.557741+00:00 app[web.1]:   File "/app/.heroku/python/lib/python3.10/site-packages/flask/app.py", line 1825, in full_dispatch_request
2023-06-22T00:35:33.557742+00:00 app[web.1]:     rv = self.handle_user_exception(e)
2023-06-22T00:35:33.557742+00:00 app[web.1]:   File "/app/.heroku/python/lib/python3.10/site-packages/flask/app.py", line 1823, in full_dispatch_request
2023-06-22T00:35:33.557742+00:00 app[web.1]:     rv = self.dispatch_request()
2023-06-22T00:35:33.557743+00:00 app[web.1]:   File "/app/.heroku/python/lib/python3.10/site-packages/flask/app.py", line 1799, in dispatch_request
2023-06-22T00:35:33.557743+00:00 app[web.1]:     return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
2023-06-22T00:35:33.557744+00:00 app[web.1]:   File "/app/app.py", line 90, in fake_mines_upload
2023-06-22T00:35:33.557745+00:00 app[web.1]:     make_mines_fake(ssc, args)
2023-06-22T00:35:33.557745+00:00 app[web.1]:   File "/app/make_mines_fake.py", line 437, in make_mines_fake
2023-06-22T00:35:33.557745+00:00 app[web.1]:     splittiming(ssc, chart)
2023-06-22T00:35:33.557745+00:00 app[web.1]:   File "/app/make_mines_fake.py", line 144, in splittiming
2023-06-22T00:35:33.557746+00:00 app[web.1]:     chart[td] = ssc[td]
2023-06-22T00:35:33.557746+00:00 app[web.1]: KeyError: 'DELAYS'
2023-06-22T00:35:33.558172+00:00 app[web.1]: 10.1.18.112 - - [22/Jun/2023:00:35:33 +0000] "POST /fake-mines HTTP/1.1" 500 265
```

I made an example file to test with no DELAYS field, no chart timing, and a mine in one chart at the same time as a note in another chart: https://gist.github.com/bkirz/16776f06b6e273a9cc4df0ce43b4888b

The file 500s in prod and is processed normally with this change applied.