### PR TITLE
Allow faking mines that appear next to hold/roll tails

### DIFF
--- a/bermuda_triangle/make_mines_fake.py
+++ b/bermuda_triangle/make_mines_fake.py
@@ -319,7 +319,7 @@ def get_notes_and_mines(ssc: simfile.ssc.SSCSimfile) -> NotesAndMines:
                     )
                     chart_mine_positions.append(position)
 
-                case NoteType.FAKE:
+                case NoteType.FAKE | NoteType.TAIL:
                     pass
 
                 case _:  # Any hittable or scoreable "note"
@@ -445,6 +445,7 @@ def make_mines_fake(
         for note_group in group_notes(
             NoteData(chart),
             same_beat_notes=SameBeatNotes.JOIN_ALL,
+            join_heads_to_tails=True,
         ):
             if any(note.note_type == NoteType.MINE for note in note_group):
                 beat = note_group[0].beat

--- a/bermuda_triangle/test/test_make_mines_fake.py
+++ b/bermuda_triangle/test/test_make_mines_fake.py
@@ -1,0 +1,31 @@
+import unittest
+import simfile
+from simfile.timing import Beat, BeatValue, BeatValues
+from bermuda_triangle import make_mines_fake
+
+class MakeMinesFakeTest(unittest.TestCase):
+    def _assert_chart_generates_fakes(self, notes: str, expected_beats: list[Beat]):
+        ssc = simfile.SSCSimfile.blank()
+        chart = simfile.ssc.SSCChart.blank()
+        chart.notes = notes
+        ssc.charts.append(chart)
+
+        args = make_mines_fake.MakeMinesFakeArgs() 
+        args.allow_simultaneous = False
+        args.allow_split_timing = False
+        make_mines_fake.make_mines_fake(ssc, args)
+        fake_beats = [fake.beat for fake in BeatValues.from_str(ssc.fakes)]
+
+        self.assertEqual(expected_beats, fake_beats)
+
+
+    def test_fake_one_mine(self):
+        self._assert_chart_generates_fakes("M000", [Beat(0)])
+    
+    def test_mine_aligned_with_tail(self):
+        self._assert_chart_generates_fakes(
+            """ 2000
+                0000
+                300M
+                0000""", 
+            [Beat(2)])


### PR DESCRIPTION
Fixes a bug in which the mine faker incorrectly skips mines aligned with hold and roll tails.